### PR TITLE
v1.30.45: predictor-driven multi-allele narrowing in pmhc query (closes #239)

### DIFF
--- a/hitlist/pmhc_query.py
+++ b/hitlist/pmhc_query.py
@@ -373,39 +373,146 @@ def query_by_samples(
 
 
 def _attach_predictions(df: pd.DataFrame, predictor: str) -> pd.DataFrame:
-    """Score each (peptide, allele) row with MHCflurry or NetMHCpan and
-    append ``affinity_nM`` / ``presentation_percentile`` / ``binder_class``.
+    """Score each row's (peptide, allele-set) and narrow multi-allele rows
+    to the single best-binding allele within their candidate set (#239).
 
-    Uses ``best_guess_allele`` as the prediction input — predictors only
-    accept 4-digit alleles, so serotype rows (HLA-A2, HLA-DR4) need the
-    heuristic 4-digit substitute. Where ``best_guess_allele`` falls back
-    to the original serotype string (no expansion available), the
-    predictor will return NaN and the row stays unscored.
+    For rows where ``mhc_allele`` is a single 4-digit allele, the
+    predictor scores that one pair and the row is unchanged apart from
+    the new score columns.  For multi-allele rows (semicolon-joined
+    typings — every per-donor row from #236, every IEDB
+    ``sample_allele_match`` row carrying the donor's full HLA typing),
+    the function:
+
+    1. Expands the row to one ``(peptide, allele)`` prediction call per
+       individual allele in the set.
+    2. Scores each pair via MHCflurry or NetMHCpan.
+    3. Picks the best binder by ``presentation_percentile`` (with
+       ``affinity_nM`` as the tiebreaker).
+    4. Narrows ``mhc_allele`` and ``best_guess_allele`` to that single
+       allele, records the choice in ``best_predicted_allele``.
+    5. Re-aggregates rows that now share the same narrowed allele
+       (e.g. SLLQHLIGL was attributed to MEL3 / MEL15 / OV1, all narrow
+       to A\\*02:01 — the three rows collapse into one with summed
+       ``n_observations`` and unioned ``pmids``).
+
+    Rows where every allele in the set returns NaN (predictor failure
+    or peptide-length mismatch) keep their original multi-allele
+    ``mhc_allele`` and have empty ``best_predicted_allele``.
     """
-    pairs = df[["peptide", "best_guess_allele"]].rename(columns={"best_guess_allele": "allele"})
+    if df.empty:
+        df = df.copy()
+        df["affinity_nM"] = pd.Series(dtype="float64")
+        df["presentation_percentile"] = pd.Series(dtype="float64")
+        df["binder_class"] = pd.Series(dtype="string")
+        df["best_predicted_allele"] = pd.Series(dtype="string")
+        return df
+
+    # Build a long frame: one (peptide, allele) candidate per individual
+    # allele in each row's best_guess_allele set, tagged with the
+    # source row's positional index so we can map results back.
+    candidates: list[dict] = []
+    for pos, (_, row) in enumerate(df.iterrows()):
+        peptide = str(row["peptide"])
+        allele_str = str(row.get("best_guess_allele") or "")
+        for allele in allele_str.split(";"):
+            allele = allele.strip()
+            if allele:
+                candidates.append({"_row_pos": pos, "peptide": peptide, "allele": allele})
+
+    if not candidates:
+        df = df.copy()
+        df["affinity_nM"] = pd.NA
+        df["presentation_percentile"] = pd.NA
+        df["binder_class"] = "non-binder"
+        df["best_predicted_allele"] = ""
+        return df
+
+    cand_df = pd.DataFrame(candidates)
+
+    # Score the unique (peptide, allele) pairs only — many rows share
+    # the same pair after the per-donor split (every Sarkizova patient
+    # carries A\*02:01, every B*07:02-only row asks the same question).
+    unique_pairs = cand_df[["peptide", "allele"]].drop_duplicates().reset_index(drop=True)
     if predictor == "mhcflurry":
         from .predict import _predict_mhcflurry
 
-        scored = _predict_mhcflurry(pairs.copy())
+        scored = _predict_mhcflurry(unique_pairs.copy())
     elif predictor == "netmhcpan":
         from .predict import _predict_netmhcpan
 
-        scored = _predict_netmhcpan(pairs.copy())
+        scored = _predict_netmhcpan(unique_pairs.copy())
     else:
         raise ValueError(f"Unknown predictor {predictor!r}; use 'mhcflurry' or 'netmhcpan'")
 
-    # NetMHCpan path returns its own DataFrame keyed on (peptide, allele);
-    # MHCflurry preserves caller index.  Merge defensively.
-    scored = scored.rename(columns={"allele": "best_guess_allele"})
-    df = df.merge(
-        scored[["peptide", "best_guess_allele", "affinity_nM", "presentation_percentile"]],
-        on=["peptide", "best_guess_allele"],
+    cand_df = cand_df.merge(
+        scored[["peptide", "allele", "affinity_nM", "presentation_percentile"]],
+        on=["peptide", "allele"],
         how="left",
     )
+
+    # Best per row: lowest presentation_percentile, then lowest affinity_nM.
+    # ``na_position="last"`` keeps unscored alleles out of the way so they
+    # only "win" when nothing in the set scored.
+    best = (
+        cand_df.sort_values(
+            ["_row_pos", "presentation_percentile", "affinity_nM"], na_position="last"
+        )
+        .drop_duplicates("_row_pos", keep="first")
+        .set_index("_row_pos")
+    )
+
+    df = df.reset_index(drop=True).copy()
+    df["affinity_nM"] = best["affinity_nM"].reindex(df.index)
+    df["presentation_percentile"] = best["presentation_percentile"].reindex(df.index)
+
+    # Narrow mhc_allele / best_guess_allele only when at least one allele
+    # in the set produced a real prediction.  ``best_predicted_allele``
+    # records the choice (empty string when no allele scored).
+    has_score = df["presentation_percentile"].notna()
+    df["best_predicted_allele"] = ""
+    df.loc[has_score, "best_predicted_allele"] = best.loc[has_score, "allele"].values
+    df.loc[has_score, "mhc_allele"] = best.loc[has_score, "allele"].values
+    df.loc[has_score, "best_guess_allele"] = best.loc[has_score, "allele"].values
+
     df["binder_class"] = [
         _classify_binder(a, p) for a, p in zip(df["affinity_nM"], df["presentation_percentile"])
     ]
-    return df
+
+    # After narrowing, the per-donor rows from #236 (3 rows for SLLQHLIGL,
+    # all of whose donor typings contain A\*02:01) collapse to a single
+    # mhc_allele.  Re-aggregate so the user sees one consolidated row
+    # per (gene, narrowed allele, peptide, class) instead of N redundant
+    # per-donor rows that all point at the same allele.
+    return _consolidate_after_narrowing(df)
+
+
+def _consolidate_after_narrowing(df: pd.DataFrame) -> pd.DataFrame:
+    """Sum ``n_observations`` and union ``pmids`` for rows that share
+    ``(gene_name, gene_id, mhc_allele, peptide, mhc_class)`` post-#239
+    narrowing.  Score columns are taken from the first row (all rows in
+    a group have the same peptide-allele pair → same prediction)."""
+    if df.empty:
+        return df
+
+    def _union_pmids(values: pd.Series) -> str:
+        seen: set[str] = set()
+        for v in values.dropna():
+            for p in str(v).split(";"):
+                if p:
+                    seen.add(p)
+        return ";".join(sorted(seen, key=int))
+
+    score_cols = ["affinity_nM", "presentation_percentile", "binder_class", "best_predicted_allele"]
+    group_cols = ["gene_name", "gene_id", "mhc_allele", "best_guess_allele", "peptide", "mhc_class"]
+    agg_spec: dict = {
+        "n_observations": "sum",
+        "pmids": _union_pmids,
+    }
+    for col in score_cols:
+        if col in df.columns:
+            agg_spec[col] = "first"
+
+    return df.groupby(group_cols, dropna=False, observed=True).agg(agg_spec).reset_index()
 
 
 # Tier ordering for taking the strongest call across affinity / percentile.

--- a/tests/test_pmhc_query.py
+++ b/tests/test_pmhc_query.py
@@ -491,6 +491,181 @@ def test_format_table_groups_by_sample_when_sample_name_present(tmp_path, monkey
     assert "HLA-A*02:01" not in p2_block  # patient2 didn't ask for A*02:01
 
 
+# ── Predictor-driven multi-allele narrowing (issue #239) ──────────────────
+
+
+def _make_grouped(rows: list[dict]) -> pd.DataFrame:
+    """Build the post-aggregation frame _attach_predictions consumes."""
+    base_cols = {
+        "gene_name": "PRAME",
+        "gene_id": "ENSG00000185686",
+        "mhc_class": "I",
+        "n_observations": 1,
+        "pmids": "31844290",
+    }
+    return pd.DataFrame([{**base_cols, **r} for r in rows])
+
+
+def test_attach_predictions_narrows_multi_allele_to_best_binder(monkeypatch):
+    """Issue #239: a multi-allele row gets expanded to per-allele
+    predictions; the lowest-percentile allele wins; mhc_allele +
+    best_guess_allele are narrowed; best_predicted_allele records the
+    choice.
+    """
+    from hitlist import pmhc_query
+
+    df = _make_grouped(
+        [
+            {
+                "peptide": "SLLQHLIGL",
+                "mhc_allele": "HLA-A*02:01;HLA-A*03:01;HLA-B*27:05",
+                "best_guess_allele": "HLA-A*02:01;HLA-A*03:01;HLA-B*27:05",
+            }
+        ]
+    )
+
+    def fake_predict(pairs: pd.DataFrame) -> pd.DataFrame:
+        # A*02:01 wins (lowest percentile); A*03:01 weak; B*27:05 non-binder.
+        scores = {
+            "HLA-A*02:01": (12.0, 0.05),
+            "HLA-A*03:01": (1500.0, 1.8),
+            "HLA-B*27:05": (8000.0, 5.5),
+        }
+        out = pairs.copy()
+        out["affinity_nM"] = [scores[a][0] for a in out["allele"]]
+        out["presentation_percentile"] = [scores[a][1] for a in out["allele"]]
+        return out
+
+    monkeypatch.setattr("hitlist.predict._predict_mhcflurry", fake_predict)
+
+    out = pmhc_query._attach_predictions(df, "mhcflurry")
+    assert len(out) == 1
+    r = out.iloc[0]
+    assert r["mhc_allele"] == "HLA-A*02:01"
+    assert r["best_guess_allele"] == "HLA-A*02:01"
+    assert r["best_predicted_allele"] == "HLA-A*02:01"
+    assert r["affinity_nM"] == 12.0
+    assert r["presentation_percentile"] == 0.05
+    assert r["binder_class"] == "strong"
+
+
+def test_attach_predictions_consolidates_per_donor_rows_after_narrowing(monkeypatch):
+    """Issue #239 + #236 interaction: three per-donor rows for SLLQHLIGL
+    (MEL3 / MEL15 / OV1, each with their own 6-allele typing) all
+    contain A*02:01.  After predictor narrowing, all three collapse to
+    a single ``HLA-A*02:01`` row with summed n_observations and the
+    union of pmids — the user sees one consolidated allele-resolved row
+    instead of three redundant per-donor rows pointing at the same
+    allele.
+    """
+    from hitlist import pmhc_query
+
+    rows = [
+        {
+            "peptide": "SLLQHLIGL",
+            "mhc_allele": "HLA-A*02:01;HLA-A*03:01;HLA-B*27:05;HLA-B*47:01;HLA-C*01:02;HLA-C*06:02",
+            "best_guess_allele": "HLA-A*02:01;HLA-A*03:01;HLA-B*27:05;HLA-B*47:01;HLA-C*01:02;HLA-C*06:02",
+            "n_observations": 2,
+            "pmids": "31844290",
+        },
+        {
+            "peptide": "SLLQHLIGL",
+            "mhc_allele": "HLA-A*02:01;HLA-A*02:02;HLA-B*13:02;HLA-B*40:02;HLA-C*02:02;HLA-C*06:02",
+            "best_guess_allele": "HLA-A*02:01;HLA-A*02:02;HLA-B*13:02;HLA-B*40:02;HLA-C*02:02;HLA-C*06:02",
+            "n_observations": 2,
+            "pmids": "31844290",
+        },
+        {
+            "peptide": "SLLQHLIGL",
+            "mhc_allele": "HLA-A*02:01;HLA-A*24:02;HLA-B*35:03;HLA-B*44:02;HLA-C*05:01;HLA-C*12:03",
+            "best_guess_allele": "HLA-A*02:01;HLA-A*24:02;HLA-B*35:03;HLA-B*44:02;HLA-C*05:01;HLA-C*12:03",
+            "n_observations": 2,
+            "pmids": "31844290",
+        },
+    ]
+    df = _make_grouped(rows)
+
+    def fake_predict(pairs: pd.DataFrame) -> pd.DataFrame:
+        # Only A*02:01 binds well; everything else is a non-binder.
+        out = pairs.copy()
+        out["affinity_nM"] = [12.0 if a == "HLA-A*02:01" else 8000.0 for a in out["allele"]]
+        out["presentation_percentile"] = [
+            0.05 if a == "HLA-A*02:01" else 5.5 for a in out["allele"]
+        ]
+        return out
+
+    monkeypatch.setattr("hitlist.predict._predict_mhcflurry", fake_predict)
+    out = pmhc_query._attach_predictions(df, "mhcflurry")
+
+    assert len(out) == 1
+    r = out.iloc[0]
+    assert r["mhc_allele"] == "HLA-A*02:01"
+    assert r["best_predicted_allele"] == "HLA-A*02:01"
+    assert r["n_observations"] == 6  # 2 + 2 + 2
+    assert r["pmids"] == "31844290"  # union of identical PMIDs
+
+
+def test_attach_predictions_keeps_single_allele_rows_unchanged(monkeypatch):
+    """Single-allele rows pass through with score columns added but no
+    structural change — mhc_allele isn't rewritten, no row collapse."""
+    from hitlist import pmhc_query
+
+    df = _make_grouped(
+        [
+            {
+                "peptide": "GILGFVFTL",
+                "mhc_allele": "HLA-A*02:01",
+                "best_guess_allele": "HLA-A*02:01",
+            }
+        ]
+    )
+
+    def fake_predict(pairs: pd.DataFrame) -> pd.DataFrame:
+        out = pairs.copy()
+        out["affinity_nM"] = [10.0]
+        out["presentation_percentile"] = [0.02]
+        return out
+
+    monkeypatch.setattr("hitlist.predict._predict_mhcflurry", fake_predict)
+    out = pmhc_query._attach_predictions(df, "mhcflurry")
+
+    assert len(out) == 1
+    r = out.iloc[0]
+    assert r["mhc_allele"] == "HLA-A*02:01"
+    assert r["best_predicted_allele"] == "HLA-A*02:01"
+    assert r["affinity_nM"] == 10.0
+    assert r["binder_class"] == "strong"
+
+
+def test_attach_predictions_keeps_multi_allele_when_no_predictions(monkeypatch):
+    """If every allele in the set returns NaN (predictor failure / length
+    mismatch / unknown allele), the multi-allele mhc_allele is preserved
+    and best_predicted_allele is empty.  Avoids wrongly committing to a
+    non-binding allele just because it sorted first."""
+    from hitlist import pmhc_query
+
+    multi = "HLA-A*02:01;HLA-A*03:01;HLA-B*27:05"
+    df = _make_grouped(
+        [{"peptide": "WEIRDPEPTIDE", "mhc_allele": multi, "best_guess_allele": multi}]
+    )
+
+    def fake_predict(pairs: pd.DataFrame) -> pd.DataFrame:
+        out = pairs.copy()
+        out["affinity_nM"] = pd.NA
+        out["presentation_percentile"] = pd.NA
+        return out
+
+    monkeypatch.setattr("hitlist.predict._predict_mhcflurry", fake_predict)
+    out = pmhc_query._attach_predictions(df, "mhcflurry")
+
+    assert len(out) == 1
+    r = out.iloc[0]
+    assert r["mhc_allele"] == multi  # unchanged
+    assert r["best_predicted_allele"] == ""
+    assert pd.isna(r["affinity_nM"])
+    assert pd.isna(r["presentation_percentile"])
+
+
 def test_query_by_samples_empty_sample_section_has_placeholder(tmp_path, monkeypatch):
     """v1.30.5: a sample whose alleles match nothing in the corpus still
     appears in the output, with a one-line ``(no pMHC evidence ...)``


### PR DESCRIPTION
## Summary

Closes #239.  Fixes the silent-NaN predictor failure on multi-allele rows that #236 made the dominant case.

When ``hitlist pmhc --predictor netmhcpan|mhcflurry`` runs against a row whose ``mhc_allele`` is a semicolon-joined set (every per-donor row from #236, every \`sample_allele_match\` row carrying a donor's full HLA typing), \`_attach_predictions\` now expands to per-allele predictions, picks the best binder, narrows the row to that allele, and re-aggregates per-donor rows that all collapse to the same allele.

### Concrete impact

\`SLLQHLIGL\` was attributed by #236 to 3 Sarkizova patient rows (MEL3 / MEL15 / OV1 typings, 6 alleles each).  Each donor's typing contains A\*02:01 — the obvious presenter for a 9-mer with hydrophobic L/L anchors.

| | Pre-#239 (post-#236) | Post-#239 |
|---|---|---|
| Number of rows | 3 (one per donor) | 1 (consolidated) |
| ``mhc_allele`` | 3 different 6-allele blobs | \`HLA-A*02:01\` |
| ``n_observations`` | 2 each (6 total) | 6 |
| ``best_predicted_allele`` | (column didn't exist) | \`HLA-A*02:01\` |
| ``affinity_nM`` / ``presentation_percentile`` | NaN (predictor couldn't parse the multi-allele string) | Real values |

## What changed

\`hitlist/pmhc_query.py\`:

1. \`_attach_predictions\` rewrites the score-and-merge step to:
   - Expand \`best_guess_allele\` (semicolon-joined) into per-allele candidate pairs.
   - Score unique \`(peptide, allele)\` pairs only — many rows share alleles after #236.
   - Sort \`(_row_pos, presentation_percentile, affinity_nM)\`, take the first per row.
   - Narrow \`mhc_allele\` / \`best_guess_allele\` to the winner; populate \`best_predicted_allele\`.
   - Falls back to keeping the multi-allele set when every allele returns NaN.
2. New helper \`_consolidate_after_narrowing\` re-groups by \`(gene, mhc_allele, best_guess_allele, peptide, mhc_class)\` to collapse per-donor rows that now share the same allele, summing \`n_observations\` and unioning \`pmids\`.

\`tests/test_pmhc_query.py\`:

- \`test_attach_predictions_narrows_multi_allele_to_best_binder\` — picks lowest-percentile from 3-allele set
- \`test_attach_predictions_consolidates_per_donor_rows_after_narrowing\` — 3 SLLQHLIGL per-donor rows → 1 consolidated row with n_obs=6
- \`test_attach_predictions_keeps_single_allele_rows_unchanged\` — no-op for single-allele rows
- \`test_attach_predictions_keeps_multi_allele_when_no_predictions\` — all-NaN preserves multi-allele set, empty \`best_predicted_allele\`

## Test plan

- [x] \`./format.sh\` clean
- [x] \`./lint.sh\` clean
- [x] \`./test.sh\` — 685 passed, 2 skipped (4 new tests)
- [ ] Manual smoke test: \`hitlist pmhc --gene PRAME --predictor mhcflurry\` should now show SLLQHLIGL on \`HLA-A*02:01\` (one row, n_obs=6) instead of 3 per-donor rows with the multi-allele blob

## Edge cases handled

- **Single-allele rows**: pass through with scores added; no \`mhc_allele\` rewrite.
- **All-NaN predictions**: keep the multi-allele set, empty \`best_predicted_allele\` (avoids wrongly committing to a non-binding allele).
- **Tied alleles**: lexicographically-first wins (deterministic; per-row context).
- **Empty input frame**: returns empty frame with the new schema columns.

## Out of scope

- Caching predictor results across query invocations (separate perf concern).
- Build-time deconvolution into \`observations.parquet\` (would force rebuild on every predictor version bump).
- Optionally keeping the full per-allele scores in a side column (one row per allele, not just the winner).
- Build-time row-count semantics — this is a query-side narrowing only.

## Stack note

Branched from \`main\` after #235 + #237 merged.  Bumps to **1.30.44**.