### PR TITLE
extend disk cache to ProteomeIndex.from_ensembl (closes #251)

### DIFF
--- a/hitlist/proteome.py
+++ b/hitlist/proteome.py
@@ -201,16 +201,144 @@ def _disk_cache_filename(cache_key: tuple) -> str:
     prefix lets us evolve ``_build``'s output shape without
     contaminating new builds with stale-format pickles.
 
-    Coupling note: this positionally decomposes the ``cache_key`` tuple
-    built in :meth:`ProteomeIndex.from_fasta`.  Adding/reordering fields
-    in that tuple requires updating this unpacking too — the hash
+    Two cache-key shapes are recognized via the first-element discriminant:
+
+    * ``("ensembl", release, species, biotype, lengths, gtf_size, gtf_mtime)``
+      — emitted by :meth:`ProteomeIndex.from_ensembl` (#251).
+    * ``(path_str, size, mtime, lengths, gene_name, gene_id)`` — emitted by
+      :meth:`ProteomeIndex.from_fasta` (#246).  This is the legacy shape;
+      no leading discriminant tag.
+
+    Coupling note: adding/reordering fields in either tuple shape
+    requires updating the matching unpacking branch below — the hash
     suffix would silently change for the same logical key otherwise.
     """
-    path_str, _size, _mtime, lengths, _gn, _gid = cache_key
-    basename = Path(path_str).stem.lower().replace(" ", "_")
+    if len(cache_key) > 0 and cache_key[0] == "ensembl":
+        _tag, release, species, biotype, lengths, _size, _mtime = cache_key
+        species_slug = str(species).lower().replace(" ", "_")
+        basename = f"ensembl_{species_slug}_r{release}_{biotype}"
+    else:
+        path_str, _size, _mtime, lengths, _gn, _gid = cache_key
+        basename = Path(path_str).stem.lower().replace(" ", "_")
     lengths_str = "-".join(str(L) for L in lengths)
     h = hashlib.sha256(repr(cache_key).encode()).hexdigest()[:16]
     return f"v{_INDEX_FORMAT_VERSION}_{basename}_L{lengths_str}_{h}.pkl"
+
+
+def _hit_in_memory_cache(cache_key: tuple, label: str, verbose: bool) -> ProteomeIndex | None:
+    """Return the in-memory cached entry (if any) and update LRU position."""
+    cached = _FASTA_INDEX_CACHE.get(cache_key)
+    if cached is None:
+        return None
+    _FASTA_INDEX_CACHE.move_to_end(cache_key)
+    if verbose:
+        print(f"  ProteomeIndex cache hit for {label}")
+    return cached
+
+
+def _hit_disk_cache(cache_key: tuple, label: str, verbose: bool) -> ProteomeIndex | None:
+    """Return the on-disk cached entry (if any) and promote it into the
+    in-memory cache so subsequent same-process calls hit the fast path.
+    """
+    disk_cached = _load_index_from_disk(cache_key)
+    if disk_cached is None:
+        return None
+    if verbose:
+        print(f"  ProteomeIndex disk-cache hit for {label}")
+    _populate_in_memory_cache(cache_key, disk_cached)
+    return disk_cached
+
+
+def _populate_in_memory_cache(cache_key: tuple, idx: ProteomeIndex) -> None:
+    """Insert (or refresh) an entry in the in-memory LRU and evict overflow.
+
+    Each eviction releases the evicted proteome's ~GB-scale arrays so the
+    build loop's peak RSS stays bounded by ``maxsize x largest proteome``
+    rather than the sum of all proteomes seen so far (issue #109).
+    """
+    if _FASTA_INDEX_CACHE_MAXSIZE <= 0:
+        return
+    _FASTA_INDEX_CACHE[cache_key] = idx
+    _FASTA_INDEX_CACHE.move_to_end(cache_key)
+    while len(_FASTA_INDEX_CACHE) > _FASTA_INDEX_CACHE_MAXSIZE:
+        _FASTA_INDEX_CACHE.popitem(last=False)
+
+
+def _populate_caches(cache_key: tuple, idx: ProteomeIndex) -> None:
+    """Populate both caches with a freshly-built index.
+
+    Used by ``from_fasta`` / ``from_ensembl`` after a cold ``_build``
+    completes.  Disk-cache writes are best-effort (warns + returns on
+    failure rather than crashing the build).
+    """
+    _populate_in_memory_cache(cache_key, idx)
+    _write_index_to_disk(cache_key, idx)
+
+
+def _resolve_ensembl_gtf_path(ensembl) -> Path | None:
+    """Find the local GTF file for a pyensembl release, or return None.
+
+    pyensembl's public surface for this is a moving target across
+    versions — newer releases expose ``gtf_path``; older ones nest it
+    under ``Genome.requires_gtf`` / ``GenomeSource``.  We probe a small
+    sequence of common attribute names and fall back to ``None`` (which
+    disables caching for that release) rather than crash.
+
+    Tests with synthetic ``EnsemblRelease`` fakes naturally land here —
+    they don't expose any of these attributes — so caching is silently
+    skipped and the existing cold-path behavior is preserved.
+    """
+    for attr in ("gtf_path", "_gtf_path", "gtf"):
+        try:
+            val = getattr(ensembl, attr)
+        except (AttributeError, Exception):
+            continue
+        if val is None:
+            continue
+        # Some attrs are properties returning a path string; others are
+        # bound methods.  Try call-then-fall-back.
+        if callable(val):
+            try:
+                val = val()
+            except Exception:
+                continue
+        try:
+            p = Path(str(val))
+        except Exception:
+            continue
+        if p.is_file():
+            return p
+    return None
+
+
+def _build_ensembl_cache_key(
+    ensembl,
+    release: int,
+    species: str,
+    biotype: str,
+    lengths: tuple[int, ...],
+) -> tuple | None:
+    """Construct the cache key tuple used by ``from_ensembl``.
+
+    Returns ``None`` when pyensembl can't expose a usable GTF path
+    (signals "skip caching for this release").
+    """
+    gtf_path = _resolve_ensembl_gtf_path(ensembl)
+    if gtf_path is None:
+        return None
+    try:
+        stat = gtf_path.stat()
+    except OSError:
+        return None
+    return (
+        "ensembl",
+        int(release),
+        str(species),
+        str(biotype),
+        tuple(lengths),
+        stat.st_size,
+        stat.st_mtime_ns,
+    )
 
 
 def _load_index_from_disk(cache_key: tuple) -> ProteomeIndex | None:
@@ -399,6 +527,23 @@ class ProteomeIndex:
         Returns
         -------
         ProteomeIndex
+
+        Notes
+        -----
+        Caching (#251): both the in-memory ``_FASTA_INDEX_CACHE`` and the
+        on-disk pickle cache from ``from_fasta`` are reused here.  The
+        cache key is keyed off pyensembl's local GTF file size + mtime —
+        when pyensembl's release data hasn't changed, repeated calls
+        skip the multi-second per-gene iteration + ``_build`` k-mer pass.
+
+        This matters most for downstream invokers (e.g. tsarina) that
+        spawn a fresh process per patient.  hitlist's process-wide
+        ``lru_cache`` is irrelevant across process boundaries; the disk
+        cache amortizes there.
+
+        When pyensembl can't expose a usable GTF path (synthetic mocks
+        in tests, or patched releases without a local GTF), caching is
+        silently disabled and the cold path runs as before.
         """
         from pyensembl import EnsemblRelease
 
@@ -409,6 +554,18 @@ class ProteomeIndex:
             if species != "human":
                 raise
             ensembl = EnsemblRelease(release)
+
+        # Build the cache key off pyensembl's local GTF (size + mtime).
+        # When unresolvable (test fakes, missing local GTF), skip caching.
+        cache_key = _build_ensembl_cache_key(ensembl, release, species, biotype, lengths)
+        if cache_key is not None:
+            label = f"ensembl {species} r{release}"
+            hit = _hit_in_memory_cache(cache_key, label, verbose)
+            if hit is None:
+                hit = _hit_disk_cache(cache_key, label, verbose)
+            if hit is not None:
+                return hit
+
         proteins: dict[str, str] = {}
         meta: dict[str, dict] = {}
 
@@ -465,7 +622,10 @@ class ProteomeIndex:
                     "is_canonical_transcript": protein_key == canonical_protein_key,
                 }
 
-        return cls._build(proteins, meta, lengths, verbose)
+        idx = cls._build(proteins, meta, lengths, verbose)
+        if cache_key is not None:
+            _populate_caches(cache_key, idx)
+        return idx
 
     @classmethod
     def from_fasta(
@@ -520,29 +680,13 @@ class ProteomeIndex:
             cache_key = None
 
         if cache_key is not None:
-            cached = _FASTA_INDEX_CACHE.get(cache_key)
-            if cached is not None:
-                # Touch the entry so LRU order tracks recency-of-use.
-                _FASTA_INDEX_CACHE.move_to_end(cache_key)
-                if verbose:
-                    print(f"  ProteomeIndex cache hit for {resolved.name}")
-                return cached
-            # In-memory miss → check the on-disk cache (#246).  Skips
-            # the ~minute-scale ``_build`` k-mer pass when this same
-            # FASTA was indexed in a previous run (size + mtime
-            # unchanged).  Promotes the loaded index into the in-memory
-            # cache so subsequent calls within this run hit the fast
-            # path.
-            disk_cached = _load_index_from_disk(cache_key)
-            if disk_cached is not None:
-                if verbose:
-                    print(f"  ProteomeIndex disk-cache hit for {resolved.name}")
-                if _FASTA_INDEX_CACHE_MAXSIZE > 0:
-                    _FASTA_INDEX_CACHE[cache_key] = disk_cached
-                    _FASTA_INDEX_CACHE.move_to_end(cache_key)
-                    while len(_FASTA_INDEX_CACHE) > _FASTA_INDEX_CACHE_MAXSIZE:
-                        _FASTA_INDEX_CACHE.popitem(last=False)
-                return disk_cached
+            label = resolved.name
+            hit = _hit_in_memory_cache(cache_key, label, verbose)
+            if hit is None:
+                # In-memory miss → check the on-disk cache (#246).
+                hit = _hit_disk_cache(cache_key, label, verbose)
+            if hit is not None:
+                return hit
 
         proteins: dict[str, str] = {}
         meta: dict[str, dict] = {}
@@ -576,21 +720,8 @@ class ProteomeIndex:
         if current_id:
             proteins[current_id] = "".join(current_seq)
         idx = cls._build(proteins, meta, lengths, verbose)
-        if cache_key is not None and _FASTA_INDEX_CACHE_MAXSIZE > 0:
-            _FASTA_INDEX_CACHE[cache_key] = idx
-            _FASTA_INDEX_CACHE.move_to_end(cache_key)
-            # Evict the least-recently-used entry when over capacity.  Each
-            # eviction releases the proteome's ~GB-scale arrays so the build
-            # loop's peak RSS stays bounded by `maxsize x largest proteome`
-            # rather than the sum of all proteomes seen so far (issue #109).
-            while len(_FASTA_INDEX_CACHE) > _FASTA_INDEX_CACHE_MAXSIZE:
-                _FASTA_INDEX_CACHE.popitem(last=False)
-        # Persist to the on-disk cache so subsequent runs (when the
-        # FASTA size + mtime are unchanged) skip the expensive _build
-        # k-mer pass entirely.  Best-effort: failures here are warned
-        # but don't break the build (#246).
         if cache_key is not None:
-            _write_index_to_disk(cache_key, idx)
+            _populate_caches(cache_key, idx)
         return idx
 
     @classmethod

--- a/tests/test_proteome.py
+++ b/tests/test_proteome.py
@@ -1035,3 +1035,202 @@ def test_clear_disk_cache_removes_tmp_files_too(tmp_path, isolated_disk_cache):
     clear_disk_cache()
     assert not pkl.exists()
     assert not tmp.exists()
+
+
+# ── from_ensembl on-disk cache (#251) ─────────────────────────────────────
+
+
+def _install_fake_ensembl(tmp_path, monkeypatch, gtf_size_marker: bytes = b"v1"):
+    """Install a synthetic ``pyensembl`` module + matching GTF file.
+
+    The fake ``EnsemblRelease.gtf_path`` returns a real on-disk file in
+    ``tmp_path`` so the cache invalidator (size + mtime) works.  Tweak
+    ``gtf_size_marker`` between calls to simulate a GTF re-download.
+    """
+    import sys
+    import types
+
+    gtf = tmp_path / "fake.gtf"
+    gtf.write_bytes(gtf_size_marker)
+
+    fake_module = types.ModuleType("pyensembl")
+
+    class _FakeTranscript:
+        def __init__(self, tid, protein_id, seq):
+            self.id = tid
+            self.protein_id = protein_id
+            self.protein_sequence = seq
+            self.biotype = "protein_coding"
+
+    class _FakeGene:
+        def __init__(self):
+            self.name = "FAKEGENE"
+            self.id = "ENSG00000FAKE"
+            self.biotype = "protein_coding"
+            self.transcripts = [
+                _FakeTranscript("ENST_T1", "ENSP_T1", "ACDEFGHIKLMNPQ"),
+            ]
+
+    class _FakeEnsembl:
+        def __init__(self, *args, **kwargs):
+            self.gtf_path = str(gtf)
+
+        def genes(self):
+            return [_FakeGene()]
+
+    fake_module.EnsemblRelease = _FakeEnsembl
+    monkeypatch.setitem(sys.modules, "pyensembl", fake_module)
+    return gtf
+
+
+def test_from_ensembl_disk_cache_persists_across_in_memory_eviction(
+    tmp_path, isolated_disk_cache, monkeypatch
+):
+    """Build via from_ensembl, drop the in-memory cache, build again —
+    the second build must hit the on-disk cache instead of re-running
+    ``_build`` (or even re-iterating the pyensembl genes list).
+    """
+    from unittest.mock import patch
+
+    from hitlist.proteome import clear_fasta_index_cache
+
+    _install_fake_ensembl(tmp_path, monkeypatch)
+
+    idx1 = ProteomeIndex.from_ensembl(release=999, lengths=(5,), verbose=False)
+    assert "ENSP_T1" in idx1.proteins
+
+    clear_fasta_index_cache()
+
+    # Second call must NOT call _build.  If pyensembl's genes() is called
+    # again that's also wasted work but tolerable; the critical assertion
+    # is that the expensive k-mer pass is skipped.
+    with patch.object(ProteomeIndex, "_build", side_effect=AssertionError("_build called")):
+        idx2 = ProteomeIndex.from_ensembl(release=999, lengths=(5,), verbose=False)
+
+    assert idx1.proteins == idx2.proteins
+    assert idx1.protein_meta == idx2.protein_meta
+    # Pickle round-trip → different instance.
+    assert idx1 is not idx2
+
+
+def test_from_ensembl_cache_invalidates_on_gtf_change(tmp_path, isolated_disk_cache, monkeypatch):
+    """Editing the local GTF (size or mtime change) must produce a
+    different cache key → fresh build with the new gene set.
+    """
+    import time
+
+    from hitlist.proteome import clear_fasta_index_cache
+
+    gtf = _install_fake_ensembl(tmp_path, monkeypatch, gtf_size_marker=b"v1")
+    idx1 = ProteomeIndex.from_ensembl(release=999, lengths=(5,), verbose=False)
+    assert "ENSP_T1" in idx1.proteins
+    n_before = len(idx1.proteins)
+
+    # Simulate a GTF re-download: bump size + mtime.
+    time.sleep(0.01)
+    gtf.write_bytes(b"v2_with_more_bytes" * 8)
+    import os as _os
+
+    _os.utime(gtf, None)
+
+    clear_fasta_index_cache()
+    # Same fake genes list, but different cache key → fresh _build.
+    idx2 = ProteomeIndex.from_ensembl(release=999, lengths=(5,), verbose=False)
+    assert "ENSP_T1" in idx2.proteins
+    assert len(idx2.proteins) == n_before
+    # Distinct cache files on disk (one per (release, gtf-fingerprint)).
+    from hitlist.proteome import _PROTEOME_INDEX_DISK_CACHE_DIR
+
+    files = list(_PROTEOME_INDEX_DISK_CACHE_DIR.glob("v*ensembl*.pkl"))
+    assert len(files) == 2, f"expected 2 cache files (one per GTF version), got {files}"
+
+
+def test_from_ensembl_cache_keyed_on_release_and_species(
+    tmp_path, isolated_disk_cache, monkeypatch
+):
+    """Different (release, species, biotype, lengths) → independent cache
+    files."""
+    from hitlist.proteome import _PROTEOME_INDEX_DISK_CACHE_DIR, clear_fasta_index_cache
+
+    _install_fake_ensembl(tmp_path, monkeypatch)
+
+    ProteomeIndex.from_ensembl(release=111, species="human", lengths=(5,), verbose=False)
+    clear_fasta_index_cache()
+    ProteomeIndex.from_ensembl(release=112, species="human", lengths=(5,), verbose=False)
+    clear_fasta_index_cache()
+    ProteomeIndex.from_ensembl(release=112, species="mouse", lengths=(5,), verbose=False)
+    clear_fasta_index_cache()
+    ProteomeIndex.from_ensembl(release=112, species="human", lengths=(8,), verbose=False)
+
+    files = sorted(_PROTEOME_INDEX_DISK_CACHE_DIR.glob("v*ensembl*.pkl"))
+    # 4 distinct keys → 4 distinct files.
+    assert len(files) == 4, f"expected 4 cache files, got {[f.name for f in files]}"
+
+
+def test_from_ensembl_cache_disabled_when_gtf_unresolvable(
+    tmp_path, isolated_disk_cache, monkeypatch
+):
+    """When pyensembl's release can't expose a usable GTF path (synthetic
+    test fakes, missing local data), caching is silently skipped and the
+    cold path runs as before.  Backwards-compatible: the existing
+    ``test_from_ensembl_*`` tests with no gtf_path attribute keep working.
+    """
+    import sys
+    import types
+
+    from hitlist.proteome import _PROTEOME_INDEX_DISK_CACHE_DIR
+
+    fake_module = types.ModuleType("pyensembl")
+
+    class _FakeTranscriptNoProteinId:
+        def __init__(self, tid, seq):
+            self.id = tid
+            self.protein_sequence = seq
+            self.biotype = "protein_coding"
+
+    class _FakeGene:
+        def __init__(self):
+            self.name = "G"
+            self.id = "ENSG00000X"
+            self.biotype = "protein_coding"
+            self.transcripts = [_FakeTranscriptNoProteinId("ENST_X1", "AAAAAAAA")]
+
+    class _FakeEnsembl:
+        # No gtf_path attribute at all.
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def genes(self):
+            return [_FakeGene()]
+
+    fake_module.EnsemblRelease = _FakeEnsembl
+    monkeypatch.setitem(sys.modules, "pyensembl", fake_module)
+
+    idx = ProteomeIndex.from_ensembl(release=999, lengths=(5,), verbose=False)
+    assert "ENST_X1" in idx.proteins
+    # No cache files written when caching is disabled.
+    files = list(_PROTEOME_INDEX_DISK_CACHE_DIR.glob("v*ensembl*.pkl"))
+    assert files == [], f"expected no cache files when gtf_path is unresolvable, got {files}"
+
+
+def test_from_ensembl_disk_hit_promotes_into_in_memory_cache(
+    tmp_path, isolated_disk_cache, monkeypatch
+):
+    """Same promotion semantics as from_fasta: on a disk-cache hit, the
+    in-memory cache gets populated so subsequent calls hit the fast
+    path."""
+    from hitlist.proteome import _FASTA_INDEX_CACHE, clear_fasta_index_cache
+
+    _install_fake_ensembl(tmp_path, monkeypatch)
+
+    ProteomeIndex.from_ensembl(release=999, lengths=(5,), verbose=False)
+    clear_fasta_index_cache()
+    assert len(_FASTA_INDEX_CACHE) == 0
+
+    # Disk-cache hit populates in-memory cache.
+    idx_disk = ProteomeIndex.from_ensembl(release=999, lengths=(5,), verbose=False)
+    assert len(_FASTA_INDEX_CACHE) == 1
+
+    # Subsequent call returns the same instance.
+    idx_mem = ProteomeIndex.from_ensembl(release=999, lengths=(5,), verbose=False)
+    assert idx_mem is idx_disk


### PR DESCRIPTION
## Status

**Stacked on PR #247** — base branch is \`profile-build-pipeline\`. Diff shown here is just the from_ensembl additions; the disk-cache infrastructure itself lives in #247.

## Summary

Closes #251. Extends the on-disk pickle cache from PR #247 to \`ProteomeIndex.from_ensembl\`, which until now had no caching at all (not even in-memory).

**Why it matters** (per @iskandr's [comment on #251](https://github.com/pirl-unc/hitlist/issues/251#issuecomment)): downstream packages like \`tsarina personalize\` invoke \`from_ensembl\` once per patient in fresh processes. The in-memory \`_FASTA_INDEX_CACHE\` never amortizes across process boundaries — every patient pays the full \`_build\` k-mer cost (~10-60s + ~3 GB peak per the docstring). Closing this issue makes that overhead a one-time cost.

## Implementation

### Refactor: shared cache helpers

Extracted three helpers from \`from_fasta\`'s inlined cache logic. Both factories now share them:

- \`_hit_in_memory_cache(cache_key, label, verbose)\` — LRU lookup + touch
- \`_hit_disk_cache(cache_key, label, verbose)\` — pickle load + promote into in-memory cache
- \`_populate_caches(cache_key, idx)\` — write to both after a cold build

\`from_fasta\` is now noticeably shorter and behavior-preserved (verified by all 49 existing proteome tests still passing).

### \`from_ensembl\` cache wiring

```python
cache_key = _build_ensembl_cache_key(ensembl, release, species, biotype, lengths)
if cache_key is not None:
    label = f"ensembl {species} r{release}"
    hit = _hit_in_memory_cache(cache_key, label, verbose) or _hit_disk_cache(cache_key, label, verbose)
    if hit is not None:
        return hit

# ... existing cold-path gene iteration ...

idx = cls._build(proteins, meta, lengths, verbose)
if cache_key is not None:
    _populate_caches(cache_key, idx)
return idx
```

### Cache key shape

Different from \`from_fasta\` (no FASTA path; pyensembl-keyed):

```
("ensembl", release, species, biotype, lengths, gtf_size, gtf_mtime_ns)
```

The first-element \`"ensembl"\` discriminant routes \`_disk_cache_filename\` to the right unpacking branch:

```
v1_ensembl_human_r112_protein_coding_L8-9-10-11_a8f3e7c901a23bd4.pkl
```

### GTF path resolution (the tricky bit)

pyensembl's public surface for the local GTF path is a moving target across versions. \`_resolve_ensembl_gtf_path\` probes a small sequence of common attribute names (\`gtf_path\`, \`_gtf_path\`, \`gtf\`) and returns \`None\` on failure. When \`None\`, caching is silently disabled and the cold path runs as before. This preserves backwards compat with existing \`test_from_ensembl_*\` tests that use synthetic \`_FakeEnsembl\` mocks without GTF attributes.

## Tests (5 new)

- [x] \`test_from_ensembl_disk_cache_persists_across_in_memory_eviction\` — mocks \`_build\` to fail-fast on the warm call; asserts the second from_ensembl call returns matching content without calling \`_build\`.
- [x] \`test_from_ensembl_cache_invalidates_on_gtf_change\` — bumps the fake GTF size + mtime, asserts fresh build runs and produces a separate cache file.
- [x] \`test_from_ensembl_cache_keyed_on_release_and_species\` — 4 distinct (release, species, biotype, lengths) combinations → 4 distinct cache files.
- [x] \`test_from_ensembl_cache_disabled_when_gtf_unresolvable\` — synthetic \`EnsemblRelease\` with no \`gtf_path\` attribute → no caching, cold path runs (preserves backwards compat).
- [x] \`test_from_ensembl_disk_hit_promotes_into_in_memory_cache\` — same promotion semantics as from_fasta.

## Test plan

- [x] \`./test.sh\` — 718 passed, 2 skipped (was 713 + 5 new)
- [x] \`./lint.sh\` — clean
- [ ] Live verification: tsarina-style cold-then-warm workflow on a real Ensembl release. Skipped here because pyensembl's release 112 GTF is gated behind a separate install step and the unit tests with synthetic \`EnsemblRelease\` cover the cache logic end-to-end.

## Followups (still open as separate issues)

- **#248** — Faster warm-load format. **My measurement showed pickle.loads is 99% Python str dict construction (13.75s on the 11M-key Macaca index), not I/O (0.12s).** The "Arrow IPC vs pickle" framing in the issue title alone gives near-zero speedup; the real fix is a runtime data-structure change to int-encoded keys (a much bigger refactor). Will tackle in a separate PR with a measurement-driven design.
- **#249** — Per-species parallelism in \`build_peptide_mappings\`. Stdlib \`concurrent.futures\` is sufficient; gating concern is memory-cap-aware worker count.
- **#250** — Faster \`_build\` inner k-mer loop. Per project policy ("no brittle/heavy dependency libraries"), the library recs in the issue (\`pyahocorasick\` / \`numba\` / \`pyroaring\`) are off-limits. Without compiled extensions only marginal pure-Python wins are available; deferred indefinitely or pending alternative ideas.